### PR TITLE
fix: Do not expose ports that should not be exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ View the firefox node via VNC (password: secret):
 
     $ open vnc://localhost:5900
 
+> **_NOTE:_**  If you want to access VNC via any public network interface you will need to update listening address in `docker-compose.yml` for `node-firefox` service
+
 After testing that bot works properly put command to run bot in crontab, like:
 
     */5 * * * * cd /path/to/the/bot; bin/bot >> kdmid-bot.log 2>&1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       GRID_NEW_SESSION_WAIT_TIMEOUT: 20000
       GRID_NODE_POLLING: 300
       GRID_TIMEOUT: 10000
-    ports:
-      - "4444:4444"
     networks:
       - watir-docker-grid-network
 
@@ -23,7 +21,7 @@ services:
       HUB_HOST: hub
       HUB_PORT: 4444
     ports:
-      - "5900:5900"
+      - "127.0.0.1:5900:5900"
     volumes:
       - /dev/shm:/dev/shm
     networks:


### PR DESCRIPTION
In case of running on a machine with public ip VNC and selenium ports are getting exposed. UFW was not able to close them. So by default let's not expose them.

If someone will need them to be exposed, they can edit docker compose