### PR TITLE
feature: Crop captchas before sending to 2captcha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM bitnami/ruby:3.1.2
 # Set LOCALE to UTF8
 RUN mkdir /gems \
     && apt update -qq \
-    && apt install -y locales build-essential sudo vim iputils-ping tzdata ffmpeg\
+    && apt install -y locales build-essential sudo vim iputils-ping tzdata imagemagick libmagickwand-dev libmagickcore-dev \
     && rm -rf /var/lib/apt/lists/* \
     && gem install bundler:2.2.33 --no-document \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM bitnami/ruby:3.1.2
 # Set LOCALE to UTF8
 RUN mkdir /gems \
     && apt update -qq \
-    && apt install -y locales build-essential sudo vim iputils-ping tzdata \
+    && apt install -y locales build-essential sudo vim iputils-ping tzdata ffmpeg\
     && rm -rf /var/lib/apt/lists/* \
     && gem install bundler:2.2.33 --no-document \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'two_captcha'
 gem 'telegram-bot-ruby'
 
 gem 'pry'
+gem 'mini_magick'
+gem 'image_processing', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,14 +18,21 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (2.1.0)
+    ffi (1.16.3)
     ice_nine (0.11.2)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     multipart-post (2.2.3)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     regexp_parser (2.5.0)
     rexml (3.2.5)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.3.0)
@@ -56,6 +63,8 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  image_processing (~> 1.0)
+  mini_magick
   pry
   selenium-webdriver (= 4.3.0)
   telegram-bot-ruby

--- a/bot.rb
+++ b/bot.rb
@@ -132,10 +132,17 @@ class Bot
 
     puts 'save captcha image to file...'
     image_filepath = "./captches/#{current_time}.png"
+    cropped_image_filepath = "./captches/#{current_time}.crop.png"
     File.write(image_filepath, captcha_image.to_png)
 
+    puts 'crop image'
+    ffmpeg_result = system 'ffmpeg', '-i', image_filepath, '-vf', "crop=in_w/3:in_h:in_w/3:0", cropped_image_filepath
+    if !ffmpeg_result
+       raise "FFMpeg crop failed"
+    end
+
     puts 'decode captcha...'
-    captcha = client.decode!(path: image_filepath)
+    captcha = client.decode!(path: cropped_image_filepath)
     captcha_code = captcha.text
     puts "captcha_code: #{captcha_code}"
 


### PR DESCRIPTION
On yerevan and gyumri kdmid sites i stumbled upon captchas, with 3 codes inside, from which only the middle one is correct. I added code for cropping the captcha with ffmpeg, but i'm not sure if it will work on all kdmid sites, and not sure if this change is needed to be merged.

Original captcha:
![Original captcha](https://github.com/accessd/kdmid-bot/assets/26447324/eab62ae5-fd93-42a6-8dbc-62a7c044e2d5)

Cropped captcha:
![Cropped captcha](https://github.com/accessd/kdmid-bot/assets/26447324/92b90aff-1bc3-49ee-8f33-4dc6be00e60f)
