### PR TITLE
This will fix InsecureCertificateError

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -15,7 +15,9 @@ class Bot
     @current_time = Time.now.utc.to_s
     puts 'Init...'
 
-    options = {}
+    options = {
+      accept_insecure_certs: true,
+    }
     if ENV['BROWSER_PROFILE']
       options.merge!(profile: ENV['BROWSER_PROFILE'])
     end


### PR DESCRIPTION
My version of Selenium (I switched to Seleniarm to use it on an M1 MPB) throws an error because the site uses HTTP instead of HTTPS. This option would not come amiss.

```ruby
options = {
  accept_insecure_certs: true,
}
```

But! AFAIK it would work only with Firefox. I cant't check it because Waitir site seems to be down🌚